### PR TITLE
Update geoformer to use cuda 11.3, pytorch 1.11.0, and spconv 2.3.6

### DIFF
--- a/.devcontainer/Dockerfile_U2004_CUDA113
+++ b/.devcontainer/Dockerfile_U2004_CUDA113
@@ -1,0 +1,48 @@
+FROM nvidia/cuda:11.3.1-devel-ubuntu20.04
+
+RUN apt-get update && apt-get install wget git -yq
+RUN apt-get install build-essential g++ gcc -y
+ENV DEBIAN_FRONTEND noninteractive
+# Unsure if openmpi is needed
+# RUN apt-get update && apt-get install libgl1-mesa-glx libglib2.0-0 libxcb-* \
+# openmpi-bin openmpi-common libopenmpi-dev libgtk2.0-dev -y  
+
+# Install miniconda
+ENV CONDA_DIR /opt/conda
+
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+     /bin/bash ~/miniconda.sh -b -p /opt/conda
+
+# Put conda in path so we can use conda activate
+ENV PATH=$CONDA_DIR/bin:/usr/local/bin:$PATH
+# general packages
+RUN conda install python=3.8
+RUN conda install numpy=1.23
+RUN conda install -c anaconda jupyter
+RUN echo "numpy==1.23.*" > /opt/conda/conda-meta/pinned
+RUN conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 cudatoolkit=11.3 -c pytorch
+RUN conda install conda=22.11 
+RUN conda install -c conda-forge setuptools=59.5
+
+# Make sure CUDA is visible
+# ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:$LD_LIBRARY_PATH
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+# ARG TORCH_CUDA_ARCH_LIST="8.9"
+# Install pointgroup_ops
+RUN apt-get install libsparsehash-dev
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+COPY lib /lib
+RUN cd /lib/pointgroup_ops && python setup.py develop
+
+# Install spconv
+RUN conda install libboost && pip install pccm
+RUN pip install spconv-cu113
+
+# Install pointnet2
+# RUN cd /lib/pointnet2 && python setup.py install
+
+# Install faiss
+RUN conda install -c conda-forge faiss-gpu
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+{
+    "build": {
+        "dockerfile": "Dockerfile_U2004_CUDA113",
+        "context": "..",
+        "args": {
+            "DOCKER_BUILDKIT": "0"
+        }
+    },
+    "mounts": [
+        "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached"
+    ],
+    "runArgs": [
+        "--gpus",
+        "all",
+        "--shm-size",
+        "16gb",
+        "-v",
+        "/tmp/.X11-unix:/tmp.X11-unix"
+    ],
+    "containerEnv": {
+        "NVIDIA_DRIVER_CAPABILITIES": "all",
+        "DISPLAY": "unix:0"
+    },
+    "forwardPorts": [
+        8887,
+        8888,
+        8886
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-toolsai.jupyter",
+                "ms-python.black-formatter"
+            ],
+            "settings": { 
+                "python.defaultInterpreterPath": "/opt/conda/bin/python",
+                "python.linting.enabled": true,
+                "python.linting.pylintEnabled": true,
+                "[python]": {
+                    "editor.defaultFormatter": "ms-python.black-formatter",
+                    "editor.formatOnSave": true
+                }
+                
+              
+            }
+        }
+    },
+    "workspaceFolder": "/workspace"
+}

--- a/checkpoint.py
+++ b/checkpoint.py
@@ -26,8 +26,12 @@ def align_and_update_state_dicts(model_state_dict, loaded_state_dict):
     loaded_keys = sorted(list(loaded_state_dict.keys()))
     # get a matrix of string matches, where each (i, j) entry correspond to the size of the
     # loaded_key string, if it matches
-    match_matrix = [len(j) if i.endswith(j) else 0 for i in current_keys for j in loaded_keys]
-    match_matrix = torch.as_tensor(match_matrix).view(len(current_keys), len(loaded_keys))
+    match_matrix = [
+        len(j) if i.endswith(j) else 0 for i in current_keys for j in loaded_keys
+    ]
+    match_matrix = torch.as_tensor(match_matrix).view(
+        len(current_keys), len(loaded_keys)
+    )
     max_match_size, idxs = match_matrix.max(1)
     # remove indices that correspond to no-match
     idxs[max_match_size == 0] = -1
@@ -44,15 +48,19 @@ def align_and_update_state_dicts(model_state_dict, loaded_state_dict):
         key = current_keys[idx_new]
         key_old = loaded_keys[idx_old]
         if loaded_state_dict[key_old].shape != model_state_dict[key].shape:
-            # if 'unet' in key or 'input_conv' in key:
-            #     reshaped = loaded_state_dict[key_old].permute(4,0,1,2,3)
-            #     loaded_state_dict[key_old] = reshaped
-            # else:
-            print(
-                "Skip loading parameter {}, required shape{}, "
-                "loaded shape{}.".format(key, model_state_dict[key].shape, loaded_state_dict[key_old].shape)
-            )
-            loaded_state_dict[key_old] = model_state_dict[key]
+            if "unet" in key or "input_conv" in key:
+                reshaped = loaded_state_dict[key_old].permute(4, 0, 1, 2, 3)
+                loaded_state_dict[key_old] = reshaped
+            else:
+                print(
+                    "Skip loading parameter {}, required shape{}, "
+                    "loaded shape{}.".format(
+                        key,
+                        model_state_dict[key].shape,
+                        loaded_state_dict[key_old].shape,
+                    )
+                )
+                loaded_state_dict[key_old] = model_state_dict[key]
 
         model_state_dict[key] = loaded_state_dict[key_old]
         logger.info(
@@ -87,7 +95,16 @@ def mkdir_p(path):
             raise
 
 
-def checkpoint(model, optimizer, epoch, log_dir, best_val=None, best_val_iter=None, postfix=None, last=False):
+def checkpoint(
+    model,
+    optimizer,
+    epoch,
+    log_dir,
+    best_val=None,
+    best_val_iter=None,
+    postfix=None,
+    last=False,
+):
     mkdir_p(log_dir)
 
     if last:
@@ -95,7 +112,11 @@ def checkpoint(model, optimizer, epoch, log_dir, best_val=None, best_val_iter=No
     else:
         filename = f"checkpoint_epoch_{epoch}.pth"
     checkpoint_file = log_dir + "/" + filename
-    state = {"epoch": epoch, "state_dict": model.state_dict(), "optimizer": optimizer.state_dict()}
+    state = {
+        "epoch": epoch,
+        "state_dict": model.state_dict(),
+        "optimizer": optimizer.state_dict(),
+    }
 
     torch.save(state, checkpoint_file)
     logging.info(f"Checkpoint saved to {checkpoint_file}")

--- a/lib/pointgroup_ops/src/bfs_cluster/bfs_cluster.h
+++ b/lib/pointgroup_ops/src/bfs_cluster/bfs_cluster.h
@@ -8,7 +8,7 @@ All Rights Reserved 2020.
 #define BFS_CLUSTER_H
 #include <torch/serialize/tensor.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <THC/THC.h>
+// #include <THC/THC.h>
 
 #include "../datatype/datatype.h"
 

--- a/model/geoformer/geoformer_modules.py
+++ b/model/geoformer/geoformer_modules.py
@@ -3,35 +3,54 @@ import spconv
 import torch
 import torch.nn as nn
 from model.transformer import TransformerEncoder
-from spconv.modules import SparseModule
+from spconv.pytorch.conv import SubMConv3d, SparseInverseConv3d, SparseConv3d
+from spconv.pytorch.modules import SparseModule, SparseSequential
+from spconv.pytorch.core import SparseConvTensor
 from util.warpper import BatchNorm1d, Conv1d
 import numpy as np
+
 
 class ResidualBlock(SparseModule):
     def __init__(self, in_channels, out_channels, norm_fn, indice_key=None):
         super().__init__()
 
         if in_channels == out_channels:
-            self.i_branch = spconv.SparseSequential(nn.Identity())
+            self.i_branch = SparseSequential(nn.Identity())
         else:
-            self.i_branch = spconv.SparseSequential(
-                spconv.SubMConv3d(in_channels, out_channels, kernel_size=1, bias=False)
+            self.i_branch = SparseSequential(
+                SubMConv3d(in_channels, out_channels, kernel_size=1, bias=False)
             )
-        self.conv_branch = spconv.SparseSequential(
+        self.conv_branch = SparseSequential(
             norm_fn(in_channels),
             nn.ReLU(),
-            spconv.SubMConv3d(in_channels, out_channels, kernel_size=3, padding=1, bias=False, indice_key=indice_key),
+            SubMConv3d(
+                in_channels,
+                out_channels,
+                kernel_size=3,
+                padding=1,
+                bias=False,
+                indice_key=indice_key,
+            ),
             norm_fn(out_channels),
             nn.ReLU(),
-            spconv.SubMConv3d(out_channels, out_channels, kernel_size=3, padding=1, bias=False, indice_key=indice_key),
+            SubMConv3d(
+                out_channels,
+                out_channels,
+                kernel_size=3,
+                padding=1,
+                bias=False,
+                indice_key=indice_key,
+            ),
         )
 
     def forward(self, input):
-        identity = spconv.SparseConvTensor(input.features, input.indices, input.spatial_shape, input.batch_size)
+        identity = SparseConvTensor(
+            input.features, input.indices, input.spatial_shape, input.batch_size
+        )
 
         output = self.conv_branch(input)
-        output.features += self.i_branch(identity).features
-
+        new_features = output.features + self.i_branch(identity).features
+        output = output.replace_feature(new_features)
         return output
 
 
@@ -39,10 +58,17 @@ class VGGBlock(SparseModule):
     def __init__(self, in_channels, out_channels, norm_fn, indice_key=None):
         super().__init__()
 
-        self.conv_layers = spconv.SparseSequential(
+        self.conv_layers = SparseSequential(
             norm_fn(in_channels),
             nn.ReLU(),
-            spconv.SubMConv3d(in_channels, out_channels, kernel_size=3, padding=1, bias=False, indice_key=indice_key),
+            SubMConv3d(
+                in_channels,
+                out_channels,
+                kernel_size=3,
+                padding=1,
+                bias=False,
+                indice_key=indice_key,
+            ),
         )
 
     def forward(self, input):
@@ -50,31 +76,46 @@ class VGGBlock(SparseModule):
 
 
 class UBlock(nn.Module):
-    def __init__(self, nPlanes, norm_fn, block_reps, block, use_backbone_transformer=False, indice_key_id=1):
+    def __init__(
+        self,
+        nPlanes,
+        norm_fn,
+        block_reps,
+        block,
+        use_backbone_transformer=False,
+        indice_key_id=1,
+    ):
 
         super().__init__()
 
         self.nPlanes = nPlanes
         blocks = {
-            "block{}".format(i): block(nPlanes[0], nPlanes[0], norm_fn, indice_key="subm{}".format(indice_key_id))
+            "block{}".format(i): block(
+                nPlanes[0],
+                nPlanes[0],
+                norm_fn,
+                indice_key="subm{}".format(indice_key_id),
+            )
             for i in range(block_reps)
         }
         blocks = OrderedDict(blocks)
-        self.blocks = spconv.SparseSequential(blocks)
+        self.blocks = SparseSequential(blocks)
         if len(nPlanes) <= 2 and use_backbone_transformer:
             d_model = 128
             self.before_transformer_linear = nn.Linear(nPlanes[0], d_model)
-            self.transformer = TransformerEncoder(d_model=d_model, N=2, heads=4, d_ff=64)
+            self.transformer = TransformerEncoder(
+                d_model=d_model, N=2, heads=4, d_ff=64
+            )
             self.after_transformer_linear = nn.Linear(d_model, nPlanes[0])
         else:
             self.before_transformer_linear = None
             self.transformer = None
             self.after_transformer_linear = None
         if len(nPlanes) > 1:
-            self.conv = spconv.SparseSequential(
+            self.conv = SparseSequential(
                 norm_fn(nPlanes[0]),
                 nn.ReLU(),
-                spconv.SparseConv3d(
+                SparseConv3d(
                     nPlanes[0],
                     nPlanes[1],
                     kernel_size=2,
@@ -85,46 +126,64 @@ class UBlock(nn.Module):
             )
 
             self.u = UBlock(
-                nPlanes[1:], norm_fn, block_reps, block, use_backbone_transformer, indice_key_id=indice_key_id + 1
+                nPlanes[1:],
+                norm_fn,
+                block_reps,
+                block,
+                use_backbone_transformer,
+                indice_key_id=indice_key_id + 1,
             )
 
-            self.deconv = spconv.SparseSequential(
+            self.deconv = SparseSequential(
                 norm_fn(nPlanes[1]),
                 nn.ReLU(),
-                spconv.SparseInverseConv3d(
-                    nPlanes[1], nPlanes[0], kernel_size=2, bias=False, indice_key="spconv{}".format(indice_key_id)
+                SparseInverseConv3d(
+                    nPlanes[1],
+                    nPlanes[0],
+                    kernel_size=2,
+                    bias=False,
+                    indice_key="spconv{}".format(indice_key_id),
                 ),
             )
 
             blocks_tail = {}
             for i in range(block_reps):
                 blocks_tail["block{}".format(i)] = block(
-                    nPlanes[0] * (2 - i), nPlanes[0], norm_fn, indice_key="subm{}".format(indice_key_id)
+                    nPlanes[0] * (2 - i),
+                    nPlanes[0],
+                    norm_fn,
+                    indice_key="subm{}".format(indice_key_id),
                 )
             blocks_tail = OrderedDict(blocks_tail)
-            self.blocks_tail = spconv.SparseSequential(blocks_tail)
+            self.blocks_tail = SparseSequential(blocks_tail)
 
     def forward(self, input):
         output = self.blocks(input)
-        identity = spconv.SparseConvTensor(output.features, output.indices, output.spatial_shape, output.batch_size)
+        identity = SparseConvTensor(
+            output.features, output.indices, output.spatial_shape, output.batch_size
+        )
 
         if len(self.nPlanes) > 1:
             output_decoder = self.conv(output)
             output_decoder = self.u(output_decoder)
             output_decoder = self.deconv(output_decoder)
 
-            output.features = torch.cat((identity.features, output_decoder.features), dim=1)
+            output = output.replace_feature(
+                torch.cat((identity.features, output_decoder.features), dim=1)
+            )
 
             output = self.blocks_tail(output)
-        
+
         if self.before_transformer_linear:
             batch_ids = output.indices[:, 0]
             xyz = output.indices[:, 1:].float()
             feats = output.features
             before_params_feats = self.before_transformer_linear(feats)
-            feats = self.transformer(xyz=xyz, features=before_params_feats, batch_ids=batch_ids)
+            feats = self.transformer(
+                xyz=xyz, features=before_params_feats, batch_ids=batch_ids
+            )
             feats = self.after_transformer_linear(feats)
-            output.features = feats
+            output = output.replace_feature(feats)
 
         return output
 
@@ -139,7 +198,13 @@ def conv_with_kaiming_uniform(norm=None, activation=None, use_sep=False):
             groups = 1
 
         conv = conv_func(
-            in_channels, out_channels, kernel_size=1, stride=1, padding=0, groups=groups, bias=(norm is None)
+            in_channels,
+            out_channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            groups=groups,
+            bias=(norm is None),
         )
 
         nn.init.kaiming_uniform_(conv.weight, a=1)
@@ -161,7 +226,6 @@ def conv_with_kaiming_uniform(norm=None, activation=None, use_sep=False):
     return make_conv
 
 
-
 def random_downsample(batch_offsets, batch_size, n_subsample=30000):
     idxs_subsample = []
     idxs_subsample_raw = []
@@ -170,14 +234,14 @@ def random_downsample(batch_offsets, batch_size, n_subsample=30000):
         num_points_b = (end - start).cpu()
 
         if n_subsample == -1 or n_subsample >= num_points_b:
-            new_inds = torch.arange(num_points_b, dtype=torch.long, device=batch_offsets.device)
+            new_inds = torch.arange(
+                num_points_b, dtype=torch.long, device=batch_offsets.device
+            )
         else:
-            new_inds = (
-                torch.tensor(
-                    np.random.choice(num_points_b, n_subsample, replace=False),
-                    dtype=torch.long,
-                    device=batch_offsets.device,
-                )
+            new_inds = torch.tensor(
+                np.random.choice(num_points_b, n_subsample, replace=False),
+                dtype=torch.long,
+                device=batch_offsets.device,
             )
         idxs_subsample_raw.append(new_inds)
         idxs_subsample.append(new_inds + start)


### PR DESCRIPTION
Hello, I am interested in using GeoFormer, but my GPU does not support CUDA 10.2, so I was forced to update to try it out. I've encountered some issues, so this is a PR/Issue. I hope that you will be able to provide me with some guidance so that I can try GeoFormer and complete the PR. 

### The error
When I run test.py or test_fs.py, there are no detections returned, and then at scene 77 the following error is raised:
```
[2024-05-25 20:34:42,976  INFO  test_fs.py  line 272  81243]  Num points: 76966 | Num instances of 10 runs: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
[2024-05-25 20:34:43,503  INFO  test_fs.py  line 269  81243]  Test scene 19/310: scene0064_00 | Elapsed time: 15s | Remaining time: 236s
[2024-05-25 20:34:43,503  INFO  test_fs.py  line 272  81243]  Num points: 230672 | Num instances of 10 runs: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
[2024-05-25 20:34:43,785  INFO  test_fs.py  line 269  81243]  Test scene 20/310: scene0064_01 | Elapsed time: 15s | Remaining time: 228s
[2024-05-25 20:34:43,785  INFO  test_fs.py  line 272  81243]  Num points: 195252 | Num instances of 10 runs: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
Failed on input scene: {'voxel_locs': tensor([[  0,  25,  20,   9],
        [  0,  25,  19,   8],
        [  0,  25,  20,   8],
        ...,
        [  0, 228,  42,   2],
        [  0, 228,  41,   2],
        [  0, 229,  41,   2]], device='cuda:0'), 'p2v_map': tensor([    0,     1,     2,  ..., 64958, 64960, 57075], device='cuda:0',
       dtype=torch.int32), 'v2p_map': tensor([[    1,     0,     0,  ...,     0,     0,     0],
        [    2,     1,   106,  ...,     0,     0,     0],
        [    2,     2,    77,  ...,     0,     0,     0],
        ...,
        [    3, 92799, 92801,  ...,     0,     0,     0],
        [    1, 92802,     0,  ...,     0,     0,     0],
        [    2, 92803, 92805,  ...,     0,     0,     0]], device='cuda:0',
       dtype=torch.int32), 'locs': tensor([[  0,  25,  20,   9],
        [  0,  25,  19,   8],
        [  0,  25,  20,   8],
        ...,
        [  0, 228,  42,   2],
        [  0, 229,  41,   2],
        [  0, 227,  44,   2]], device='cuda:0'), 'locs_float': tensor([[-1.4505, -0.7623, -0.8699],
        [-1.4424, -0.7747, -0.8870],
        [-1.4458, -0.7634, -0.8874],
        ...,
        [ 2.6209, -0.3197, -1.0005],
        [ 2.6300, -0.3277, -0.9942],
        [ 2.6002, -0.2715, -1.0065]], device='cuda:0'), 'feats': tensor([[-0.9765, -0.9765, -0.9922],
        [-0.9843, -0.9843, -0.9922],
        [-0.9765, -0.9765, -0.9922],
        ...,
        [-0.8353, -0.8667, -0.9059],
        [-0.8353, -0.8667, -0.9059],
        [-0.8275, -0.8745, -0.8980]], device='cuda:0'), 'spatial_shape': array([231, 171, 139]), 'batch_offsets': tensor([    0, 92807], device='cuda:0', dtype=torch.int32), 'pc_mins': tensor([[-1.9537, -1.1645, -1.0521]], device='cuda:0', dtype=torch.float64), 'pc_maxs': tensor([[2.6526, 2.2472, 1.7230]], device='cuda:0', dtype=torch.float64), 'labels': tensor([2, 2, 1,  ..., 1, 1, 1], device='cuda:0')} with output_feats: tensor([], device='cuda:0', size=(0, 16))
Traceback (most recent call last):
  File "test_fs.py", line 352, in <module>
    do_test(
  File "test_fs.py", line 198, in do_test
    outputs = model(
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/workspace/model/geoformer/geoformer_fs.py", line 565, in forward
    raise e
  File "/workspace/model/geoformer/geoformer_fs.py", line 558, in forward
    mask_features_ = self.mask_tower(
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/container.py", line 141, in forward
    input = module(input)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/container.py", line 141, in forward
    input = module(input)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/workspace/util/warpper.py", line 145, in forward
    x = super().forward(x)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/conv.py", line 302, in forward
    return self._conv_forward(input, self.weight, self.bias)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/conv.py", line 298, in _conv_forward
    return F.conv1d(input, weight, bias, self.stride,
RuntimeError: Calculated padded input size per channel: (0). Kernel size: (1). Kernel size can't be greater than actual input size
```
I've used a breakpoint to trace the issue, and at some point the scores are just too low, so an empty list is returned. [From the spconv](https://github.com/traveller59/spconv/blob/125a194d895b1bc3ad6ff907bc72641548397b32/docs/SPCONV_2_BREAKING_CHANGEs.md) documentation, weight layout in 1.x uses RSCK, but 2.x uses RSKC or KRSC. With the 2.x default set, the model weights will only load if I uncomment your [weight permutation in the loading script](https://github.com/VinAIResearch/GeoFormer/blob/main/checkpoint.py#L47C1-L50C20). However, I get the empty detections and the error described above. I have also tried re-commenting those lines with the weight layout set to "RSCK", "RSKC", and "KRSC", but all result in shape mismatches between the model definition and the loaded weights. I suspect that I am getting these empty detections due to an incorrect loading order of the weights. Perhaps the input and output are swapped, or the weight for x coordinate swapped with the weight for z, etc.? That would result in correct layer sizes, but spurious model results. Could you print out the weight values of one of the model layers as it loads for you with spconv 1.x and cuda 10.2? If I know the values I can check if the order of the weights is loading correctly. 


### Changes Made
I've added a Dockerfile to use CUDA 11.3, spconv 2.3.6 for CUDA 11.3, and pytorch 1.11.0. Pytorch was upgraded to this version to avoid [this bug with MinkowskiEngine](https://github.com/NVIDIA/MinkowskiEngine/issues/395). If you use my Dockerfile, note that I installed pointgroup_ops and pointnet2 from within the container rather than during the image build. You may not encounter this problem, but I was unable to get docker to recognize CUDA during the build to install those packages, but it did inside the container. 

I [removed THC](https://github.com/adidier17/GeoFormer/commit/22992b787f1b5003a7d1ef1d92aee74bd815e56c#diff-207861a6ef022fe0110a87446b19dfbfdb3dd91a51ea9f6b0125bc640afc55c2R11),

and [updated the imports for spconv](https://github.com/adidier17/GeoFormer/commit/22992b787f1b5003a7d1ef1d92aee74bd815e56c#diff-24c16b43c297e95b561ce6cb84b6520433a02257439029bfc728518b9eacea81).
Those are the relevant changes. Other changes were automatic from my python linter.


Please let me know if you have any other thoughts on why the detections returned are empty. 